### PR TITLE
Fix list task

### DIFF
--- a/bin/avm
+++ b/bin/avm
@@ -63,7 +63,7 @@ display_help() {
     avm prev                       Revert to the previously activated version
     avm --latest                   Output the latest appium version available
     avm ls                         Output the versions of appium available for install
-    avm list                         Output the versions of appium installed
+    avm list                       Output the versions of appium installed
 
   Options:
 

--- a/bin/avm
+++ b/bin/avm
@@ -62,7 +62,8 @@ display_help() {
     avm rm <version ...>           Remove the given version(s)
     avm prev                       Revert to the previously activated version
     avm --latest                   Output the latest appium version available
-    avm ls                         Output the versions of appium available
+    avm ls                         Output the versions of appium available for install
+    avm list                         Output the versions of appium installed
 
   Options:
 
@@ -73,7 +74,6 @@ display_help() {
 
     which   bin
     as      use
-    list    ls
     -       rm
 
 EOF
@@ -363,6 +363,7 @@ else
       latest) install_appium `avm --latest`; exit ;;
       prev) activate_previous; exit ;;
       ls) display_available_versions; exit ;;
+      list) list_versions_installed; exit ;;
       *) install_appium $1; exit ;;
     esac
     shift


### PR DESCRIPTION
Previously avm list resulted in trying to install appium with "list" version:
```
myMachine:~ user$ avm list

     install : vlist
       mkdir : /usr/local/avm/versions/list
     install : list
npm ERR! code ETARGET
npm ERR! notarget No matching version found for appium@list
npm ERR! notarget In most cases you or one of your dependencies are requesting
npm ERR! notarget a package version that doesn't exist.

npm ERR! A complete log of this run can be found in:
npm ERR!     /Users/user/.npm/_logs/2018-07-12T16_05_48_600Z-debug.log
          rm : /usr/local/avm/versions/list

  Error: appium list install failed
```

I added a case in switch and fixed inline help.